### PR TITLE
Jv 82 link images splash

### DIFF
--- a/components/SplashScreen.js
+++ b/components/SplashScreen.js
@@ -25,26 +25,38 @@ const SplashScreen = () => {
       <View style={styles.bigContainer}>
       <View>
           <Pressable>
-            <Text style={styles.names}>Kendrick Mausolf</Text>
+            <Text style={styles.names}>Github:</Text>
+            <Text style={styles.names}>Kmausolf</Text>
             <Image style={styles.github} source={kendrick8bit} />
+            <Text style={styles.names}>Kendrick</Text>
+            <Text style={styles.names}>Mausolf</Text>
           </Pressable>
         </View>
         <View>
           <Pressable>
-            <Text style={styles.names}>Kenneth Ferrell II</Text>
+            <Text style={styles.names}>Github:</Text>
+            <Text style={styles.names}>Krferrell</Text>
             <Image style={styles.github} source={kenny8bit} />
+            <Text style={styles.names}>Kenneth</Text>
+            <Text style={styles.names}>Ferrell II</Text>
           </Pressable>
         </View>
         <View>
           <Pressable>
-            <Text style={styles.names}>Luis Perez</Text>
+            <Text style={styles.names}>Github:</Text>
+            <Text style={styles.names}>Lap343</Text>
             <Image style={styles.github} source={luis8bit} />
+            <Text style={styles.names}>Luis</Text>
+            <Text style={styles.names}>Perez</Text>
           </Pressable>
         </View>
         <View>
           <Pressable>
-            <Text style={styles.names}>Jorge Villalobos</Text>
+            <Text style={styles.names}>Github:</Text>
+            <Text style={styles.names}>JorgeLVilla</Text>
             <Image style={styles.github} source={jorge8bit} />
+            <Text style={styles.names}>Jorge</Text>
+            <Text style={styles.names}>Villalobos</Text>
           </Pressable>
         </View>
       </View>
@@ -68,20 +80,20 @@ const styles = StyleSheet.create({
     alignItems: "center",
     flexDirection: "row",
     position: "absolute",
-    top: 155
+    top: 120
   },
 
   github: {
     height: 125,
     width: 125,
-    margin: 20,
+    margin: 10,
   },
   names: {
     textAlign: "center",
     fontSize: 19
   },
   title: {
-    fontSize: 50,
+    fontSize: 35,
     top: 70,
     textDecorationLine: "underline",
     color: "black",
@@ -90,7 +102,6 @@ const styles = StyleSheet.create({
   text: {
     color: "#fff",
     fontSize: 20,
-    textDecorationLine: "underline",
   },
   shadowText: {
     textShadowColor: "rgba(0, 0, 0, 0.75)",


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Adds developers' GitHub account names to splash scree/credits. 

## Purpose
We decided that just including the names of our GitHub accounts on the credits screen would be better suited for the flow of the app. We do not want to take away from the experience of a continuous play flow.

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #82 