### PR TITLE
bug(replay-button): fix replay button

### DIFF
--- a/components/LevelSelect.js
+++ b/components/LevelSelect.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Dimensions, ImageBackground, StyleSheet, View, Text, Image, Pressable } from 'react-native';
-import { Link } from 'react-router-native';
 import { gamesList } from '../utils/randomGameSelect';
 import backgroundImg from '../assets/cloudBackground.png';
 import arrow from '../assets/arrow.png'
@@ -21,7 +20,7 @@ const LevelSelect = ({ navigation, route }) => {
 
     const [ page, setPage ] = useState(1);
 
-    const fromModal = route.params.fromModal 
+    const fromModal = route?.params?.fromModal 
 
     const gamesListView = () => {
         return (

--- a/components/MainMenu.js
+++ b/components/MainMenu.js
@@ -51,11 +51,11 @@ const MainMenu = ({ navigation }) => {
             <View style={styles.buttonContainer}>
 
               <Pressable onPress={() => navigation.navigate('Random Game Select', { fromGameSelect: false })}>
-                <Text style={[styles.buttons, styles.shadowText, {fontFamily: loaded ? "SchoolBell" : null}]}>Start</Text>
+                <Text style={[styles.buttons, styles.shadowText, {fontFamily: loaded ? "SchoolBell" : null}]}>Games Start</Text>
               </Pressable>
 
               <Pressable onPress={() => navigation.navigate('Level Select', { fromModal: false })}>
-                <Text style={[styles.buttons, styles.shadowText, {fontFamily: loaded ? "SchoolBell" : null}]}>Game Select</Text>
+                <Text style={[styles.buttons, styles.shadowText, {fontFamily: loaded ? "SchoolBell" : null}]}>Practice Games</Text>
               </Pressable>
 
               <Pressable onPress={() => navigation.navigate('Profile Page')}>

--- a/components/MenuModal.js
+++ b/components/MenuModal.js
@@ -25,9 +25,6 @@ const MenuModal = () => {
     const fromGameSelect = route.params.fromGameSelect
     const chosenGameKey = route.params.chosenGame
 
-    console.log("game array length", gamesArray.length)
-    console.log("game index plus 1", gameIndex + 1)
-
     return (
         <View style={ styles.modalPageBackground}>
             <View style={ styles.modalContainer}>

--- a/components/MenuModal.js
+++ b/components/MenuModal.js
@@ -23,6 +23,10 @@ const MenuModal = () => {
     const route = useRoute();
 
     const fromGameSelect = route.params.fromGameSelect
+    const chosenGameKey = route.params.chosenGame
+
+    console.log("game array length", gamesArray.length)
+    console.log("game index plus 1", gameIndex + 1)
 
     return (
         <View style={ styles.modalPageBackground}>
@@ -50,6 +54,29 @@ const MenuModal = () => {
                 {
                     (gameState === 'LOSE' || gameState === 'WIN') &&
                     (
+                        // If the game is selected from the game select screen, at the end of the game the modal will ask if the player wants to replay the game 
+                        fromGameSelect ?
+                        <Pressable
+                                style={styles.playButton} 
+                                onPress={() => {
+                                    dispatch(resetLives())
+                                    dispatch(changeGame("PLAY"))
+                                    dispatch(saveIndex(0))
+                                        navigation.reset({
+                                            index: 0,
+                                            routes: [
+                                                { name: 'Level Select' },
+                                                {
+                                                    name: 'Random Game Select',
+                                                    params: { fromGameSelect: true, chosenGame: chosenGameKey },
+                                                },
+                                            ],
+                                        })
+                                }}
+                        >
+                            <Text style={[styles.modalText, styles.addShadow]}>Replay</Text>
+                        </Pressable> :
+                        // If not from the game select screen the modal will only ask to replay if you pass the final game
                         gamesArray.length === (gameIndex + 1) ?
                         <Pressable
                             style={styles.playButton} 


### PR DESCRIPTION
## Changes
1. Have the replay button work differently depending on the game mode
- If from the main game mode the replay button will reshuffle all the games and reset your finished games position to none
- if from the practice game mode the game will just replay 

## Purpose
To have a working replay button so a player can keep playing a game without having to go back to the main page


Closes #103 